### PR TITLE
Add double elims support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Bases:
     Quarter -> quarter + final
     
     Semifinal -> semi + final
+
+    Double Eliminations -> double elims
     
     Final -> final
     
@@ -48,6 +50,8 @@ Bases:
 QM15 = `Qualification Match 15.mp4` or `Qual 15.mp4`
 
 SF2M3 = `Semifinal Tiebreaker 2.mp4` or `semi final tiebreak 2.mp4`
+
+(Double Elims TBA format) SF10M1 = `Double Elims 10.mp4` (case insensitive)
 
 F1M3 = `Final 3.mp4` or `final tiebreaker.mp4` (The FMS shows Final 3, but I allow either tiebreaker or 3 for naming)
 

--- a/frcuploader/forms.py
+++ b/frcuploader/forms.py
@@ -204,9 +204,10 @@ class FRC_Uploader(BaseWidget):
         for t in consts.VALID_PRIVACY_STATUSES:
             self._privacy += t
         self._mtype += ("Qualifications", "qm")
+        self._mtype += ("Double Elims", "double-elims")
+        self._mtype += ("Finals", "f1m")
         self._mtype += ("Quarterfinals", "qf")
         self._mtype += ("Semifinals", "sf")
-        self._mtype += ("Finals", "f1m")
         self._ceremonies += ("None", 0)
         self._ceremonies += ("Opening Ceremonies", 1)
         self._ceremonies += ("Alliance Selection", 2)

--- a/frcuploader/main.py
+++ b/frcuploader/main.py
@@ -13,10 +13,6 @@ from .updatePlaylistThumbnails import main as uptmain
 
 
 def main():
-    print(os.path.isfile(consts.youtube_oauth_file))
-    print(len(os.listdir(consts.yt_accounts_folder)))
-    print(consts.yt_accounts_folder)
-    print(os.listdir(consts.yt_accounts_folder))
     try:
         if os.path.isfile(consts.youtube_oauth_file) or not len(
             os.listdir(consts.yt_accounts_folder)

--- a/frcuploader/main.py
+++ b/frcuploader/main.py
@@ -13,6 +13,11 @@ from .updatePlaylistThumbnails import main as uptmain
 
 
 def main():
+    print(os.path.isfile(consts.youtube_oauth_file))
+    print(len(
+            os.listdir(consts.yt_accounts_folder)))
+    print(consts.yt_accounts_folder)
+    print(os.listdir(consts.yt_accounts_folder))
     try:
         if os.path.isfile(consts.youtube_oauth_file) or not len(
             os.listdir(consts.yt_accounts_folder)

--- a/frcuploader/main.py
+++ b/frcuploader/main.py
@@ -14,8 +14,7 @@ from .updatePlaylistThumbnails import main as uptmain
 
 def main():
     print(os.path.isfile(consts.youtube_oauth_file))
-    print(len(
-            os.listdir(consts.yt_accounts_folder)))
+    print(len(os.listdir(consts.yt_accounts_folder)))
     print(consts.yt_accounts_folder)
     print(os.listdir(consts.yt_accounts_folder))
     try:

--- a/frcuploader/playlistToTBA.py
+++ b/frcuploader/playlistToTBA.py
@@ -168,13 +168,17 @@ def main():
                 fb,
                 weblink,
             )
-        elif any(x in title for x in ["R1", "R2", "R3", "R4", "R5"]): # Double eliminations
+        elif any(
+            x in title for x in ["R1", "R2", "R3", "R4", "R5"]
+        ):  # Double eliminations
             try:
-                extracted_match_num = title[title.find('Match') + 5:].split(' ')[1]
+                extracted_match_num = title[title.find("Match") + 5 :].split(" ")[1]
                 mnum = double_elims_match_code(mtype=None, mnum=extracted_match_num)
             except IndexError as e:
                 print(e)
-                raise ValueError(f"Unable to extract match number from Double Elims match with title {title}")
+                raise ValueError(
+                    f"Unable to extract match number from Double Elims match with title {title}"
+                )
 
             print(f"Posting {mnum}")
             consts.tba.add_match_videos({mnum: video_id})

--- a/frcuploader/playlistToTBA.py
+++ b/frcuploader/playlistToTBA.py
@@ -7,6 +7,7 @@ from .utils import (
     quarters_match_code,
     semis_match_code,
     finals_match_code,
+    double_elims_match_code,
     tiebreak_mnum,
     get_match_results,
 )
@@ -153,6 +154,28 @@ def main():
             if "Tiebreak" in title:
                 num = tiebreak_mnum(num, "sf")
             mnum = semis_match_code("sf", num)
+            print(f"Posting {mnum}")
+            consts.tba.add_match_videos({mnum: video_id})
+            update_description(
+                youtube,
+                playlist_item,
+                video_id,
+                ecode,
+                mnum,
+                ename,
+                team,
+                twit,
+                fb,
+                weblink,
+            )
+        elif any(x in title for x in ["R1", "R2", "R3", "R4", "R5"]): # Double eliminations
+            try:
+                extracted_match_num = title[title.find('Match') + 5:].split(' ')[1]
+                mnum = double_elims_match_code(mtype=None, mnum=extracted_match_num)
+            except IndexError as e:
+                print(e)
+                raise ValueError(f"Unable to extract match number from Double Elims match with title {title}")
+
             print(f"Posting {mnum}")
             consts.tba.add_match_videos({mnum: video_id})
             update_description(

--- a/frcuploader/utils.py
+++ b/frcuploader/utils.py
@@ -46,6 +46,7 @@ def file_size(path):
 def quals_yt_title(options):
     return options.title if not options.replay else f"{options.title} Replay"
 
+
 def double_elims_yt_title(options):
     mnum = options.mnum
     round_num = None
@@ -65,7 +66,9 @@ def double_elims_yt_title(options):
     elif mnum == 13:
         round_num = 5
     else:
-        raise ValueError("Double Eliminations match number must be within 1 and 13 (inclusive)")
+        raise ValueError(
+            "Double Eliminations match number must be within 1 and 13 (inclusive)"
+        )
 
     is_replay = options.replay
 
@@ -74,6 +77,7 @@ def double_elims_yt_title(options):
         return f"{base_match_name} - Replay"
 
     return base_match_name
+
 
 def quarters_yt_title(options):
     mnum = options.mnum
@@ -163,6 +167,7 @@ def quals_filename(options):
                     break
     return file
 
+
 def double_elims_filename(options):
     file = None
     for f in options.files:
@@ -182,6 +187,7 @@ def double_elims_filename(options):
                     file = f
                     break
     return file
+
 
 def quarters_filename(options):
     file = None
@@ -355,15 +361,19 @@ def quals_match_code(mtype, mnum):
     match_code = str(mtype) + str(mnum)
     return match_code
 
+
 def double_elims_match_code(mtype, mnum):
     print("double_elims_mc", mnum)
     mnum = int(mnum)
     # See https://github.com/the-blue-alliance/the-blue-alliance/pull/5025
 
     if mnum < 1 or mnum > 13:
-        raise ValueError("Double Eliminations match number must be between 1 and 13, inclusive")
+        raise ValueError(
+            "Double Eliminations match number must be between 1 and 13, inclusive"
+        )
 
     return f"sf{mnum}m1"
+
 
 def quarters_match_code(mtype, mnum):
     match_set = str(mnum % 4)

--- a/frcuploader/utils.py
+++ b/frcuploader/utils.py
@@ -46,6 +46,34 @@ def file_size(path):
 def quals_yt_title(options):
     return options.title if not options.replay else f"{options.title} Replay"
 
+def double_elims_yt_title(options):
+    mnum = options.mnum
+    round_num = None
+    # Round 1 - matches 1-4
+    if mnum <= 4:
+        round_num = 1
+    # Round 2 - matches 5-8
+    elif mnum <= 8:
+        round_num = 2
+    # Round 3 - matches 9-10
+    elif mnum <= 10:
+        round_num = 3
+    # Round 4 - matches 11-12
+    elif mnum <= 12:
+        round_num = 4
+    # Round 5 - match 13
+    elif mnum == 13:
+        round_num = 5
+    else:
+        raise ValueError("Double Eliminations match number must be within 1 and 13 (inclusive)")
+
+    is_replay = options.replay
+
+    base_match_name = f"{options.ename} - Playoffs Match {mnum} (R{round_num})"
+    if is_replay:
+        return f"{base_match_name} - Replay"
+
+    return base_match_name
 
 def quarters_yt_title(options):
     mnum = options.mnum
@@ -135,6 +163,25 @@ def quals_filename(options):
                     break
     return file
 
+def double_elims_filename(options):
+    file = None
+    for f in options.files:
+        fl = f.lower()
+        if all(
+            [
+                " " + str(options.mnum) + "." in fl
+                and any(k in fl for k in ("double elims", "double eliminations"))
+            ]
+        ):
+            if options.replay:
+                if "replay" in fl:
+                    file = f
+                    break
+            else:
+                if "replay" not in fl:
+                    file = f
+                    break
+    return file
 
 def quarters_filename(options):
     file = None
@@ -281,12 +328,14 @@ def create_names(options):
             "qf": quarters_filename,
             "sf": semis_filename,
             "f1m": finals_filename,
+            "double-elims": double_elims_filename,
         }
         yt = {
             "qm": quals_yt_title,
             "qf": quarters_yt_title,
             "sf": semis_yt_title,
             "f1m": finals_yt_title,
+            "double-elims": double_elims_yt_title,
         }
         try:
             if options.newest:
@@ -306,6 +355,15 @@ def quals_match_code(mtype, mnum):
     match_code = str(mtype) + str(mnum)
     return match_code
 
+def double_elims_match_code(mtype, mnum):
+    print("double_elims_mc", mnum)
+    mnum = int(mnum)
+    # See https://github.com/the-blue-alliance/the-blue-alliance/pull/5025
+
+    if mnum < 1 or mnum > 13:
+        raise ValueError("Double Eliminations match number must be between 1 and 13, inclusive")
+
+    return f"sf{mnum}m1"
 
 def quarters_match_code(mtype, mnum):
     match_set = str(mnum % 4)
@@ -349,13 +407,14 @@ def get_match_code(mtype, mnum, mcode):
             "qf": quarters_match_code,
             "sf": semis_match_code,
             "f1m": finals_match_code,
+            "double-elims": double_elims_match_code,
         }
         return switcher[mtype](mtype, mnum)
     print(f"Uploading as {mcode}")
     return mcode.lower()
 
 
-"""Data Compliation and Adjustment Functions"""
+"""Data Compilation and Adjustment Functions"""
 
 
 def get_match_results(event_key, match_key):
@@ -427,6 +486,9 @@ def create_description(
 
 
 def tiebreak_mnum(mnum, mtype):
+    if mtype == "double-elims":
+        raise ValueError("Tiebreak not supported for Double Elims matches")
+
     switcher = {
         "qm": mnum,
         "qf": mnum + 8,
@@ -462,6 +524,8 @@ def add_to_playlist(videoID, playlistID):
 
 
 def post_video(token, secret, match_video, event_key, loc="match_videos"):
+    if consts.DEBUG:
+        print("TBA post_video POST data", match_video)
     trusted_auth = {"X-TBA-Auth-Id": "", "X-TBA-Auth-Sig": ""}
     trusted_auth["X-TBA-Auth-Id"] = token
     request_path = f"/api/trusted/v1/event/{event_key}/{loc}/add"


### PR DESCRIPTION
Allow uploading double elimination format playoff matches
* Per TBA API, double elim matches (always 13) have match keys like `sf{match_num}m1`
* In Youtube videos, the title will reference the match as `Playoffs Match # (R#)`, where `R#` is the playoff round number
* Choose `Double Elims` match type and name files like `double elims 1.mp4`, etc
* Also added support for double elims on the playlistToTBA script